### PR TITLE
Windowをフォアグラウンド化する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ This function recursively calls `ChildWindowFromPointEx` until the last descenda
 A shortcut to win32 API `ChildWindowFromPointEx(hWnd, point, Window.WindowFromPointFlags.CWP_ALL)`.
 This function recursively calls `ChildWindowFromPointEx` until the last descendant window and returns an instance of `IEmumerable<WindowInfo>`.
 
+##### Activate()
+Brings window into the foreground and activates the window.
+
 ### SendInput
 
 Send mouse and keyboard input events to the foreground window. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ skip_non_tags: false
 
 image: Visual Studio 2015
 
-version: 2.3.{build}
+version: 2.4.{build}
 
 assembly_info:
   patch: true


### PR DESCRIPTION
WindowInfo.Activate()を追加。
ジェスチャ定義で以下のものが書けるようになります (ctx.PointedWindow.Activate())。
```csharp:default.csx
Browser.
@on(RightButton).
@if(WheelUp).
@do((ctx) =>
{
    ctx.PointedWindow.Activate(); //ポインタ直下のWindowへアクションが行くようフォアグラウンド化
    SendInput.Multiple().
    ExtendedKeyDown(VK_CONTROL).
    //...
});
```

背景としてジェスチャ操作をポインタ直下のウィンドウへ行いたいのですが、WindowInfo.BringWindowToTop()がうまく動かないです。そのため、期待通りフォアグラウンド化ができるメソッドを実装しました。この類は本体側で実装するとdefault.csxがジェスチャに専念でき、良いと思いました。